### PR TITLE
fix(dm-indicator): hide indicator when no one is typing

### DIFF
--- a/dmtypingindicator/style.css
+++ b/dmtypingindicator/style.css
@@ -15,6 +15,10 @@
   color: var(--interactive-hover);
 }
 
+.dm-typing-indicator.false {
+  display: none;
+}
+
 .dm-typing-badge {
   border-radius: 8px;
   width: 20px;


### PR DESCRIPTION
before
![before](https://user-images.githubusercontent.com/36301891/190149548-8f3db4af-bfad-4dc8-a1b6-ed42a094cbd5.png)
after
![after](https://user-images.githubusercontent.com/36301891/190149533-fc64cd9e-8015-4691-aca7-395bb88ac459.png)

hii sarah